### PR TITLE
Changed recommendations for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [[*next-version*]] - YYYY-MM-DD
+### Changed
+- Recommendations for tests: func tests test integrity, unit tests test storage access.
+
+## [0.1] - 2016-07-06
+Initial version.

--- a/code-standards/php.md
+++ b/code-standards/php.md
@@ -258,9 +258,9 @@ rules.
     declaring stub classes. If declared, such classes MUST use a base 
     namespace of the form `<Vendor>\<Package>\TestStub`. Protected methods
     SHOULD be tested as well as public ones, which is true of any functionality.
-    Tests for getters and setters SHOULD NOT test protected properties;
-    instead, such tests SHOULD test that the values returned
-    by the getters are predicted by those set by the setters. Setters and
+    Unit tests for getters and setters SHOULD test protected properties, if this is where values are stored.
+    Functional tests for getters and setters SHOULD test that the values returned
+    by the getters are predicted by those set by the setters. Functionally, setters and
     getters are not guaranteed to read or write to/from any specific location,
     as long as value integrity is preserved. Remember: protected methods
     are an API too, but for descendants instead of external consumers.


### PR DESCRIPTION
- Tests of getters and setters now have separate recommendations for unit tests and functional tests.
- Functional tests SHOULD test integrity of values.
- Unit tests should test access to storage medium.